### PR TITLE
Don't send empty and blank messages

### DIFF
--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -22,9 +22,11 @@
   });
 
   sendbtn.addEventListener('click', () => {
-    console.log(`Sending message to ${room_id_of_other_user}`);
-    socket.emit('sendMessage', { "room": room_id_of_other_user, "message": message.value });
-    message.value = ' ';
+    if((message.value.trim()).length !== 0) {
+      console.log(`Sending message to ${room_id_of_other_user}`);
+      socket.emit('sendMessage', { "room": room_id_of_other_user, "message": message.value });
+      message.value = ' ';
+    }
   });
 
   socket.on('private ack', (data) => {


### PR DESCRIPTION
If the message box is empty or has only blank spaces the message doesn't get sent by clicking enter.


Fixes #62 